### PR TITLE
Use pure thrust

### DIFF
--- a/include/shuffle/BijectiveFunctionScanShuffle.h
+++ b/include/shuffle/BijectiveFunctionScanShuffle.h
@@ -1,27 +1,85 @@
 #pragma once
-#include <thrust/device_vector.h>
-
 #include "DefaultRandomGenerator.h"
 #include "shuffle/Shuffle.h"
-#include <cub/cub.cuh>
+#include <thrust/execution_policy.h>
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/transform_iterator.h>
+#include <thrust/iterator/transform_output_iterator.h>
+#include <thrust/device_vector.h>
 
+
+struct KeyFlagTuple
+{
+    uint64_t key;
+    uint64_t flag;
+};
+
+struct ScanOp
+{
+    __device__ KeyFlagTuple operator()( const KeyFlagTuple& a, const KeyFlagTuple& b )
+    {
+        return { b.key, a.flag + b.flag };
+    }
+};
+
+template <class BijectiveFunction>
+struct MakeTupleFunctor
+{
+    uint64_t m;
+    BijectiveFunction mapping_function;
+    MakeTupleFunctor( uint64_t m, BijectiveFunction mapping_function )
+        : m( m ), mapping_function( mapping_function )
+    {
+    }
+    __device__ KeyFlagTuple operator()( uint64_t idx )
+    {
+        auto gather_key = mapping_function( idx );
+        return KeyFlagTuple{ gather_key, gather_key < m };
+    }
+};
+
+template <typename InputIterT, typename OutputIterT>
+struct WritePermutationFunctor
+{
+    uint64_t m;
+    InputIterT in;
+    OutputIterT out;
+    __device__ size_t operator()( KeyFlagTuple x )
+    {
+        if( x.key < m )
+        {
+            // -1 because inclusive scan
+            out[x.flag - 1] = in[x.key];
+        }
+        return 0; // Discarded
+    }
+};
+
+struct cached_allocator
+{
+    typedef char value_type;
+
+    thrust::device_vector<char> memory;
+
+    char* allocate( std::ptrdiff_t num_bytes )
+    {
+        memory.resize( num_bytes );
+        return memory.data().get();
+    }
+
+    void deallocate( char* ptr, size_t )
+    {
+    }
+};
 
 template <class BijectiveFunction, class ContainerType = thrust::device_vector<uint64_t>, class RandomGenerator = DefaultRandomGenerator>
 class BijectiveFunctionScanShuffle : public Shuffle<ContainerType, RandomGenerator>
 {
-    thrust::device_vector<uint8_t> temp_storage;
+    cached_allocator alloc;
 
 public:
-    BijectiveFunctionScanShuffle()
-    {
-        temp_storage.resize( 1 << 16 );
-    }
-
     void shuffle( const ContainerType& in_container, ContainerType& out_container, uint64_t seed, uint64_t num ) override
     {
-        using ValueT = typename ContainerType::value_type;
         assert( &in_container != &out_container );
 
         RandomGenerator random_function( seed );
@@ -29,36 +87,16 @@ public:
         mapping_function.init( num, random_function );
         uint64_t capacity = mapping_function.getMappingRange();
 
-        thrust::counting_iterator<uint64_t> indexes( 0 );
+        thrust::counting_iterator<uint64_t> indices( 0 );
         size_t m = num;
-        auto input_iter = in_container.begin();
-        auto mapping_it = thrust::make_transform_iterator( indexes, [=] __device__( uint64_t val ) -> ValueT {
-            auto gather_key = mapping_function( val );
-            if( gather_key < m )
-            {
-                return input_iter[gather_key];
-            }
-            return ValueT();
-        } );
-        auto flag_it = thrust::make_transform_iterator( indexes, [=] __device__( uint64_t val ) {
-            auto gather_key = mapping_function( val );
-            return gather_key < m;
-        } );
-
-        auto output_it = out_container.begin();
-        // Determine temporary device storage requirements
-        size_t temp_storage_bytes = 0;
-        cub::DeviceSelect::Flagged( nullptr, temp_storage_bytes, mapping_it, flag_it, output_it,
-                                    thrust::discard_iterator<int>(), capacity );
-        // Allocate temporary storage
-        if( temp_storage.size() < temp_storage_bytes )
-        {
-            temp_storage.resize( temp_storage_bytes );
-        }
-        // Run selection
-        cub::DeviceSelect::Flagged( reinterpret_cast<void*>( temp_storage.data().get() ),
-                                    temp_storage_bytes, mapping_it, flag_it, output_it,
-                                    thrust::discard_iterator<int>(), capacity );
+        thrust::transform_iterator<MakeTupleFunctor<BijectiveFunction>, decltype( indices ), KeyFlagTuple> tuple_it(
+            indices, MakeTupleFunctor<BijectiveFunction>( m, mapping_function ) );
+        WritePermutationFunctor<decltype( in_container.begin() ), decltype( out_container.begin() )> write_functor{
+            m, in_container.begin(), out_container.begin()
+        };
+        auto output_it =
+            thrust::make_transform_output_iterator( thrust::discard_iterator<size_t>(), write_functor );
+        thrust::inclusive_scan( thrust::cuda::par( alloc ), tuple_it, tuple_it + capacity, output_it, ScanOp() );
     }
 
     bool supportsInPlace() const override


### PR DESCRIPTION
This PR converts the scan shuffle to use pure thrust and removes the second function call.

All tests passing.

Some benchmarks on V100:

| Size   | Old (G/s) | New (G/s) | Speedup |
|--------|-----------|-----------|---------|
| 2^18+1 | 3.82      | 4.42      | 1.16    |
| 2^27+1 | 3.60      | 4.07      | 1.13    |
| 2^29+1 | 3.51      | 3.965     | 1.13    |